### PR TITLE
API returns empty object

### DIFF
--- a/server.py
+++ b/server.py
@@ -176,10 +176,7 @@ def store(key):
   except:
     return internal_server_error(message="Failed to store key")
 
-  return jsonify({
-    'key': key,
-    'value': value,
-  })
+  return jsonify(value)
 
 @app.route('/<path:key>', methods=['DELETE'])
 def delete(key):
@@ -203,12 +200,9 @@ def delete(key):
   '''
 
   if db_delete(key):
-    return jsonify({
-      'key': key,
-      'deleted': True,
-    })
+    return jsonify({}), 200  # 200: Gone
   else:
-    return not_found(message="No such key: %s" % (key,))
+    return jsonify({}), 404  # 404: Not found
 
 @app.route('/<path:key>', methods=['GET'])
 def fetch(key):
@@ -238,7 +232,7 @@ def fetch(key):
 
   result = db_fetch(key)
   if result is None:
-    return not_found(message="No such key: %s" % (key,))
+    return jsonify({}), 404  # 404: Not found
 
   return jsonify(result)
 

--- a/server_test.py
+++ b/server_test.py
@@ -27,22 +27,19 @@ class ServerTestCase(unittest.TestCase):
         res = self.client.get(PATH)
         self.assertEqual(res.status_code, 404)
         res_json = res.get_json()
-        self.assertIn("error", res_json)
-        self.assertIn("status", res_json)
+        self.assertEqual(res_json, {})
 
         # deleting should be 404
         res = self.client.delete(PATH)
         self.assertEqual(res.status_code, 404)
         res_json = res.get_json()
-        self.assertIn("error", res_json)
-        self.assertIn("status", res_json)
+        self.assertEqual(res_json, {})
 
         # now we create it
         res = self.client.post(PATH, json=data)
         self.assertEqual(res.status_code, 200)
         res_json = res.get_json()
-        self.assertEqual(res_json["value"]["one"], 1)
-        self.assertEqual(res_json["key"], KEY)
+        self.assertEqual(res_json["one"], 1)
 
         # now it should exist
         res = self.client.get(PATH)
@@ -54,14 +51,13 @@ class ServerTestCase(unittest.TestCase):
         res = self.client.delete(PATH)
         self.assertEqual(res.status_code, 200)
         res_json = res.get_json()
-        self.assertEqual(res_json, {'key': KEY, 'deleted': True})
+        self.assertEqual(res_json, {})
 
         # now it should no longer exist
         res = self.client.get(PATH)
         self.assertEqual(res.status_code, 404)
         res_json = res.get_json()
-        self.assertIn("error", res_json)
-        self.assertIn("status", res_json)
+        self.assertEqual(res_json, {})
 
     def test_updates(self):
         data = {"number": 1}
@@ -75,29 +71,29 @@ class ServerTestCase(unittest.TestCase):
         # now create it
         res = self.client.post(PATH, json=data)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.get_json()["value"]["number"], 1)
+        self.assertEqual(res.get_json(), data)
 
         # check that we can retrieve it correctly
         res = self.client.get(PATH)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.get_json()["number"], 1)
+        self.assertEqual(res.get_json(), data)
 
         # now post to it again
         data = {"number": 42}
         res = self.client.post(PATH, json=data)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.get_json()["value"]["number"], 42)
+        self.assertEqual(res.get_json(), data)
 
         # now post to it yet again
         data = {"number": 123}
         res = self.client.post(PATH, json=data)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.get_json()["value"]["number"], 123)
+        self.assertEqual(res.get_json(), data)
 
         # check that it has actually been updated
         res = self.client.get(PATH)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.get_json()["number"], 123)
+        self.assertEqual(res.get_json(), data)
 
     def test_invalid_input(self):
         # not json


### PR DESCRIPTION
Change the storage API to return empty JSON object (along with 404) when key not found, also all responses are now values rather than `{"key": blah, "value": othervalue}`.